### PR TITLE
Add a property `key` to the `SessionVar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ if st.button(label=f"Increase '{my_instance.name}'"):
 You can bind Streamlit widgets directly to class attributes using their session keys:
 
 ```python
-st.text_input(label="MyPersistentClass.name", key=f"{my_instance.__instance_key__}.name")
+st.text_input(label="MyPersistentClass.name", key=my_instance.name.key)
 
 st.write(f"The current value on the 'MyPersistentClass.name' is '{my_instance.name}'")
 ```

--- a/src/streamlit_meta_state/core.py
+++ b/src/streamlit_meta_state/core.py
@@ -32,6 +32,10 @@ class SessionVar:
         """
         self.name: str = name
 
+        # Store the session state key for this attribute, generated when
+        # `_make_key` is called.
+        self._key: str | None = None
+
     @property
     def cache_name(self) -> str:
         """
@@ -41,6 +45,18 @@ class SessionVar:
             str: The cache name, which is the attribute name prefixed with an underscore.
         """
         return f"_{self.name}"
+    
+    @property
+    def key(self) -> str:
+        """
+        Get the session state key for this attribute.
+
+        Returns:
+            str: The session state key in the format '<instance_key>.<attribute_name>'.
+        """
+        if self._key is None:
+            raise ValueError("SessionVar key not set")
+        return self._key
 
     def _make_key(self, instance) -> str:
         """
@@ -52,7 +68,8 @@ class SessionVar:
         Returns:
             str: A unique key in the format '<instance_key>.<attribute_name>'.
         """
-        return f"{instance.__instance_key__}.{self.name}"
+        self._key = f"{instance.__instance_key__}.{self.name}"
+        return self._key
 
     def __get__(self, instance, owner) -> Any:
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,7 @@ if st.button(label=f"Increase '{my_instance.name}'"):
     st.rerun()
 
 st.text_input(
-    label="MyPersistentClass.name", key=f"{my_instance.__instance_key__}.name"
+    label="MyPersistentClass.name", key=my_instance.name.key
 )
 
 st.write(f"The current value on the 'MyPersistentClass.name' is '{my_instance.name}'")


### PR DESCRIPTION
The instance key is being recovered using a private attribute, like in README example.
```python
st.text_input(label="MyPersistentClass.name", key=f"{my_instance.__instance_key__}.name")
```

A less dangerous approach would be to provide a cached property `key` to the `SessionVar` class to recover the same information.
```python
st.text_input(label="MyPersistentClass.name", key=my_instance.name.key)
```